### PR TITLE
Make environment font step configurable

### DIFF
--- a/src/Commands/DecreaseEnvironmentFontSize.cs
+++ b/src/Commands/DecreaseEnvironmentFontSize.cs
@@ -1,5 +1,6 @@
 ﻿using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Shell;
+using FontSizer.Options;
 using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
 
@@ -10,7 +11,10 @@ namespace FontSizer.Commands
     {
         protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
         {
-            await Helper.AdjustFontSizeAsync(FontsAndColorsCategory.DialogsAndToolWindows, -2);
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            short step = VSPackage.Instance?.GetEnvironmentFontStep() ?? GeneralOptionsPage.DefaultEnvironmentFontStep;
+            await Helper.AdjustFontSizeAsync(FontsAndColorsCategory.DialogsAndToolWindows, (short)-step);
         }
     }
 }

--- a/src/Commands/DecreaseEnvironmentFontSize.cs
+++ b/src/Commands/DecreaseEnvironmentFontSize.cs
@@ -1,6 +1,6 @@
 ﻿using Community.VisualStudio.Toolkit;
-using Microsoft.VisualStudio.Shell;
 using FontSizer.Options;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/Commands/Helper.cs
+++ b/src/Commands/Helper.cs
@@ -37,7 +37,17 @@ namespace FontSizer.Commands
                     return;
                 }
 
-                pInfo[0].wPointSize = checked((ushort)(pInfo[0].wPointSize + change));
+                int newPointSize = pInfo[0].wPointSize + change;
+                if (newPointSize < 1)
+                {
+                    newPointSize = 1;
+                }
+                else if (newPointSize > ushort.MaxValue)
+                {
+                    newPointSize = ushort.MaxValue;
+                }
+
+                pInfo[0].wPointSize = (ushort)newPointSize;
                 ErrorHandler.ThrowOnFailure(storage.SetFont(pInfo));
                 ErrorHandler.ThrowOnFailure(utilities.FreeFontInfo(pInfo));
             }

--- a/src/Commands/IncreaseEnvironmentFontSize.cs
+++ b/src/Commands/IncreaseEnvironmentFontSize.cs
@@ -1,5 +1,6 @@
 ﻿using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Shell;
+using FontSizer.Options;
 using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
 
@@ -10,7 +11,10 @@ namespace FontSizer.Commands
     {
         protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
         {
-            await Helper.AdjustFontSizeAsync(FontsAndColorsCategory.DialogsAndToolWindows, 2);
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            short step = VSPackage.Instance?.GetEnvironmentFontStep() ?? GeneralOptionsPage.DefaultEnvironmentFontStep;
+            await Helper.AdjustFontSizeAsync(FontsAndColorsCategory.DialogsAndToolWindows, step);
         }
     }
 }

--- a/src/Commands/IncreaseEnvironmentFontSize.cs
+++ b/src/Commands/IncreaseEnvironmentFontSize.cs
@@ -1,6 +1,6 @@
 ﻿using Community.VisualStudio.Toolkit;
-using Microsoft.VisualStudio.Shell;
 using FontSizer.Options;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/FontSizer.csproj
+++ b/src/FontSizer.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Commands\Helper.cs" />
     <Compile Include="Commands\IncreaseEnvironmentFontSize.cs" />
     <Compile Include="Commands\IncreaseFontSize.cs" />
+    <Compile Include="Options\GeneralOptionsPage.cs" />
     <Compile Include="source.extension.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/Options/GeneralOptionsPage.cs
+++ b/src/Options/GeneralOptionsPage.cs
@@ -1,0 +1,44 @@
+﻿using System.ComponentModel;
+using Microsoft.VisualStudio.Shell;
+
+namespace FontSizer.Options
+{
+    public class GeneralOptionsPage : DialogPage
+    {
+        public const short MinEnvironmentFontStep = 1;
+        public const short MaxEnvironmentFontStep = 10;
+        public const short DefaultEnvironmentFontStep = 2;
+
+        private short _environmentFontStep = DefaultEnvironmentFontStep;
+
+        [Category("Environment")]
+        [DisplayName("Environment font step")]
+        [Description("Point-size delta used by the environment increase/decrease commands.")]
+        public short EnvironmentFontStep
+        {
+            get => _environmentFontStep;
+            set => _environmentFontStep = Clamp(value);
+        }
+
+        protected override void OnApply(PageApplyEventArgs e)
+        {
+            _environmentFontStep = Clamp(_environmentFontStep);
+            base.OnApply(e);
+        }
+
+        private static short Clamp(short value)
+        {
+            if (value < MinEnvironmentFontStep)
+            {
+                return MinEnvironmentFontStep;
+            }
+
+            if (value > MaxEnvironmentFontStep)
+            {
+                return MaxEnvironmentFontStep;
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/VSPackage.cs
+++ b/src/VSPackage.cs
@@ -2,6 +2,7 @@
 using System.Runtime.InteropServices;
 using System.Threading;
 using FontSizer.Commands;
+using FontSizer.Options;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
 
@@ -10,12 +11,24 @@ namespace FontSizer
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [InstalledProductRegistration(Vsix.Name, Vsix.Description, Vsix.Version)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
+    [ProvideOptionPage(typeof(GeneralOptionsPage), "Font Sizer", "General", 0, 0, true)]
     [Guid(PackageGuids.guidIncreaseFontSizePackageString)]
     public sealed class VSPackage : AsyncPackage
     {
+        internal static VSPackage Instance { get; private set; }
+
+        internal short GetEnvironmentFontStep()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var options = (GeneralOptionsPage)GetDialogPage(typeof(GeneralOptionsPage));
+            return options?.EnvironmentFontStep ?? GeneralOptionsPage.DefaultEnvironmentFontStep;
+        }
+
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            await JoinableTaskFactory.SwitchToMainThreadAsync();
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            Instance = this;
 
             await IncreaseFontSize.InitializeAsync(this);
             await DecreaseFontSize.InitializeAsync(this);


### PR DESCRIPTION
## Summary
- add a new Options page (Tools > Options > Font Sizer > General)
- make environment font step configurable (Environment font step)
- keep default at 2 to preserve existing behavior
- clamp configured value to 1..10`r
- guard font size updates against underflow/overflow in Helper.AdjustFontSizeAsync`r

## Notes
- no VSIX identity/branding changes included
